### PR TITLE
Remove begin wait on scan and fix some layout issues on the main page

### DIFF
--- a/app/src/main/java/org/gheskio/queue/MainActivity.java
+++ b/app/src/main/java/org/gheskio/queue/MainActivity.java
@@ -152,33 +152,8 @@ public class MainActivity extends BaseActivity {
         EditText tokenText = (EditText) findViewById(R.id.qrCode);
         if (requestCode == QRCODEINTENT) {
             if (resultCode == RESULT_OK) {
-
-
                 qrCode = intent.getStringExtra("SCAN_RESULT");
                 tokenText.setText(qrCode);
-                mEditText = ((EditText) findViewById(R.id.qrCode));
-                String tokenVal = mEditText.getText().toString().trim();
-
-
-                if (tokenVal.length() > 0) {
-                    // check to be sure token isn't already given...
-                    String queryString = "select give_time from simpleq where token_id = '" +
-                            tokenVal + "' and duration = 0";
-                    String args[] = {};
-
-                    Cursor c = MainActivity.myDB.rawQuery(queryString, args);
-                    if (c.getCount() > 0) {
-                        InfoDialog.show(MainActivity.this, getString(R.string.token_already_given));
-                    } else {
-                        new SimpleQRecord(tokenVal, "", "start_wait");
-                        Button editButton = (Button) findViewById(R.id.editButton);
-                        editButton.setEnabled(true);
-                    }
-                    c.close();
-                } else {
-                    InfoDialog.show(MainActivity.this, getString(R.string.token_id_needed));
-                }
-
             }
         } else if (requestCode == EDITRECORDINTENT) {
             if (resultCode == RESULT_OK) {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,7 @@
 <GridLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
 
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:useDefaultMargins="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:columnCount="4"
@@ -113,7 +110,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_row="5"
-        android:layout_column="1"
+        android:layout_column="2"
         android:onClick="doSkip"
         android:text="@string/skip_button" />
 
@@ -184,6 +181,21 @@
         android:layout_column="3"
         android:onClick="doEndWait"
         android:text="@string/end_wait_label" />
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_columnWeight="1"
+
+        android:layout_row="8"
+        android:layout_column="1"/>
+
+    <Space
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_rowWeight="1"
+
+        android:layout_row="9"
+        android:layout_column="0"/>
 
     <Button
         android:id="@+id/beginWaitButton"
@@ -200,6 +212,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_column="0"
+
         android:layout_row="10"
         android:onClick="doPrefs"
         android:text="@string/prefs_label" />
@@ -212,7 +225,7 @@
         android:layout_rowSpan="2"
         android:layout_column="2"
         android:layout_columnSpan="2"
-        android:layout_gravity="end"
+        android:layout_gravity="bottom|end"
         android:scaleType="fitCenter"
         android:onClick="doQRScan"
         android:src="@drawable/qrcode2_icon" />

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
 
     android:columnOrderPreserved="true"
     android:rowCount="12"
-    android:orientation="vertical"
+    android:orientation="horizontal"
     tools:context=".MainActivity">
 
     <TextView
@@ -138,7 +138,7 @@
 
     <EditText
         android:id="@+id/qrCode"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_row="6"
         android:layout_column="1"
@@ -158,7 +158,7 @@
 
     <EditText
         android:id="@+id/comments"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_row="7"
         android:layout_column="1"


### PR DESCRIPTION
This PR removes the feature that begins the wait on scan such that the user must click "begin wait" to start the patient wait. It also fixes some layout issues in the main activity page, which were causing display issues in the Moto G6 phones.